### PR TITLE
Renders all posts

### DIFF
--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -2,13 +2,10 @@ const router = require('express').Router();
 const { Post, Comment, User } = require('../models');
 const withAuth = require('../utils/auth');
 
-// TODO: GET all posts for homepage
 
-
+//Homepage is accessible without logging in
 router.get('/', async (req, res) => {
     // Send the rendered Handlebars.js template back as the response
-    res.render('homepage');
-
     try {
         // Get all posts and JOIN with user data
         const postData = await Post.findAll({
@@ -17,16 +14,21 @@ router.get('/', async (req, res) => {
                     model: User,
                     attributes: ['username'],
                 },
-                {
-                    model: Comment,
-                    attributes: ['title', 'body'],
-                },
+                // {
+                //     model: Comment,
+                //     attributes: [
+                //         'title',
+                //         'body',
+                //         'created_at',
+                //     ],
+                //     include: {
+                //         model: User,
+                //         attributes: ['username'],
+                //     }
+                // },
             ],
         });
-
-        // Serialize data so the template can read it
         const posts = postData.map((post) => post.get({ plain: true }));
-
         // Pass serialized data and session flag into template
         res.render('homepage', {
             posts,
@@ -40,6 +42,7 @@ router.get('/', async (req, res) => {
 
 
 router.get('/login', (req, res) => {
+    //Once the user is logged in, the user should be redirected to the homepage
     if (req.session.loggedIn) {
         res.redirect('/');
         return;
@@ -58,7 +61,7 @@ router.get('/signup', (req, res) => {
 });
 
 //add withAuth middleware to only allow dashboard access if the user is logged in
-router.get('/dashboard', async (req, res) => {
+router.get('/dashboard', withAuth, async (req, res) => {
     if (req.session.loggedIn) {
         res.redirect('/');
         return;

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -1,12 +1,12 @@
 <div class="d-flex flex-column"><!--the container for all the posts should be in column form-->
-    {{#each post as |post|}}
+    {{#each posts as |post|}}
     <div class="d-block mt-3">
         <div class="post-header d-flex flex-row align-items-baseline justify-content-between pt-1">
             <h2 class="homepage-post-title col-6 ps-1">
                 <a href="/post/{{post.id}}">{{post.title}}</a>
             </h2>
             <h5 class="pe-2">
-                created by {{post.user.name}} on {{format_date project.date_created}}
+                created by {{post.user.username}} on {{format_date post.createdAt}}
             </h5>
         </div>
         <div class="post-main">

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -25,34 +25,26 @@
                     IT Blog
                 </a>
                 <div class="ml-auto">
-                    <!-- Conditionally render login or logout links -->
-                    {{!-- {{#if logged_in}} --}}
                     <a href="/">Home</a> |
                     <a href="/dashboard">Dashboard</a> |
-                    {{!-- <button class="out-button" id="logout">Log out</button>
-                    {{else}} --}}
+                    <!-- Conditionally render login or logout links -->
+                    {{#if logged_in}}
+                    <button class="out-button" id="logout">Log out</button>
+                    {{else}}
                     <a href="/login">Log in</a>
-                    {{!-- {{/if}} --}}
+                    {{/if}}
                 </div>
             </div>
         </nav>
     </header>
 
     <main class="container container-fluid mt-5">
-        <!-- Render the sub layout -->
         {{{ body }}}
     </main>
-
-
-
 
     <!-- Render script for logged in users only - Allows the Log Out button to function -->
     {{#if logged_in}}
     <script src="/js/logout.js"></script>
-    {{else logging_in}}
-    <script src="/js/password.js"></script>
-    {{else sign_up}}
-    <script src="/js/password.js"></script>
     {{/if}}
 
 </body>


### PR DESCRIPTION
This update renders all the posts from the MySQL interesting_tech_db database to the homepage with the user and date created along with the title and body of the post. This was thanks to the vital error of not adding an *s* to posts on line 2 of `views/homepage.handlebars` In addition, line 9 had to change names to usernames to match the column name in the User model, and `project` had to be changed to `post` to match the model.

Also, the dashboard is now inaccessible without logging in. Users will be redirected to the login page after clicking Dashboard if they are not already logged in. If they are, the normal dashboard appears.

A current error that needs to be resolved is that after clicking Log In or Sign Up, the page is not redirected.